### PR TITLE
Feature/use GitHub app

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,13 @@ you can use an issue template to make typing easier.
 
 refs: [sample issue template](https://github.com/hilotter/github-gantt-chart/tree/master/.github/ISSUE_TEMPLATE)
 
+- install GitHub App & grant access to the repository you want to view the gantt chart
+
+https://github.com/apps/gantt-chart
 
 - show gantt chart on below site
 
 https://github-gantt-chart.herokuapp.com/gantt/{username}/{reponame}
-
-Example(require login): https://github-gantt-chart.herokuapp.com/gantt/hilotter/github-gantt-chart
 
 ## Build Setup
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -9,6 +9,16 @@
         </div>
         <div class="block flex-grow flex items-center w-auto">
           <div class="text-sm flex-grow"></div>
+          <div>
+            <a
+              :href="githubAppUrl"
+              target="_blank"
+              rel="noopener"
+              class="inline-block text-sm px-4 py-2 leading-none border rounded border-white hover:border-transparent hover:text-gray-500 hover:bg-white mt-0"
+            >
+              {{ githubAppLinkText }}
+            </a>
+          </div>
           <div v-if="!isLogInPage">
             <nuxt-link
               :to="loginLink"
@@ -47,6 +57,12 @@ import { SITE_NAME } from '~/commonHead'
 export default Vue.extend({
   computed: {
     ...mapState('auth', ['loggedIn']),
+    githubAppUrl() {
+      return process.env.GITHUB_APP_URL!
+    },
+    githubAppLinkText() {
+      return this.loggedIn ? 'GitHub App Setting' : 'Install GitHub App'
+    },
     siteName() {
       return SITE_NAME
     },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -93,6 +93,7 @@ const config: Configuration = {
     END_DATE_STRING_TEMPLATE: process.env.END_DATE_STRING_TEMPLATE!,
     PROGRESS_STRING_TEMPLATE: process.env.PROGRESS_STRING_TEMPLATE!,
     DEPENDENCIES_STRING_TEMPLATE: process.env.DEPENDENCIES_STRING_TEMPLATE!,
+    GITHUB_APP_URL: process.env.GITHUB_APP_URL!,
   },
   /*
    ** Build configuration

--- a/pages/gantt/_owner/_name.vue
+++ b/pages/gantt/_owner/_name.vue
@@ -77,7 +77,17 @@ export default Vue.extend({
     this.owner = owner
     this.repoName = name
 
-    const queryResult = await this.getRepoIssues(owner, name)
+    const queryResult = await this.getRepoIssues(owner, name).catch((err) => {
+      alert(
+        `Can not access this repository issues.\nPlease add to access permission to this repository from GitHub App Setting.\n\nDetail: ${err.message}`
+      )
+      this.$router.push(`/gantt/${owner}`)
+    })
+
+    if (!queryResult) {
+      return
+    }
+
     const issues = queryResult.edges.map((issue) => {
       const { title, number, body, url } = issue.node
       return { title, number, body, url }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -5,11 +5,24 @@
       <li class="mb-4">
         <p class="mb-4">add gantt chart item in your issue.</p>
         <div class="bg-gray-100">
-          {{ startDateFormat() }} 2020-04-01<br />
-          {{ endDateFormat() }} 2020-04-10<br />
-          {{ progressFormat() }} 0.5<br />
-          {{ dependenciesFormat() }} #1, #2
+          {{ startDateFormat }} 2020-04-01<br />
+          {{ endDateFormat }} 2020-04-10<br />
+          {{ progressFormat }} 0.5<br />
+          {{ dependenciesFormat }} #1, #2
         </div>
+      </li>
+      <li class="mb-4">
+        <a
+          :href="githubAppUrl"
+          target="_blank"
+          rel="noopener"
+          class="underline"
+        >
+          install gantt-chart GitHub App
+        </a>
+      </li>
+      <li class="mb-4">
+        grant access to the repository you want to view the gantt chart.
       </li>
       <li class="mb-4">
         <nuxt-link class="underline" to="/login">Login</nuxt-link>
@@ -40,7 +53,10 @@ import Vue from 'vue'
 
 export default Vue.extend({
   auth: false,
-  methods: {
+  computed: {
+    githubAppUrl() {
+      return process.env.GITHUB_APP_URL!
+    },
     startDateFormat() {
       return process.env.START_DATE_STRING_TEMPLATE
     },


### PR DESCRIPTION
# why
- The permissions of the OAuth app are too powerful.
- Use Github App so that the minimum required permissions can be set